### PR TITLE
Remove hard dependency on cuda driver library + sparsehash include dir

### DIFF
--- a/src/3rd_party/fast_align/CMakeLists.txt
+++ b/src/3rd_party/fast_align/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 find_package(SparseHash)
 if(SPARSEHASH_FOUND)
   add_definitions(-DHAVE_SPARSEHASH)
+  include_directories(${SPARSEHASH_INCLUDE_DIR})
 endif(SPARSEHASH_FOUND)
 
 find_package(OpenMP QUIET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,7 +130,7 @@ endif(PYTHONLIBS_FOUND)
 
 foreach(exec ${EXES})
   if(CUDA_FOUND)
-    target_link_libraries(${exec} ${EXT_LIBS} cuda)
+    target_link_libraries(${exec} ${EXT_LIBS})
     cuda_add_cublas_to_target(${exec})
   else(CUDA_FOUND)
     target_link_libraries(${exec} ${EXT_LIBS})


### PR DESCRIPTION
amun/amunmt binaries have a dependency on the CUDA driver library. As far as I can tell, it only uses the runtime API, so the driver dependency can be discarded. This is not a huge problem, but it can cause a compilation error on systems where libcuda.so is placed outside of the normal library search path.